### PR TITLE
WIP: Support nested methods and event emitters

### DIFF
--- a/lib/method-chain-utils.js
+++ b/lib/method-chain-utils.js
@@ -1,0 +1,78 @@
+// A "method chain" is a way of statically expressing a chain of method calls.
+// E.g. Math.pow(2, 4) is expressed as [['pow', [2, 4]]]. It also supports
+// deeply dested and chained calls e.g. myApi.things.get(4).filter('foo') would
+// be expressed as: [['things'], ['get', [4]], ['filter', ['foo']]] These parse
+// and stringify functions are used for encoding the event name with the method
+// they apply to, because we need to use a single event emitter to simulate
+// multiple event emitters (because every method and submethod on our proxied
+// API is an event emitter) to avoid memory leaks
+
+/** @typedef {import('./types').MethodChain} MethodChain */
+
+module.exports = {
+  stringify,
+  parse,
+  isValidMethodChain,
+  getMethodString,
+}
+
+const divider = '\uffff'
+/**
+ * @param {MethodChain} methodChain
+ * @param {string} eventName
+ * @returns {string}
+ */
+function stringify(methodChain, eventName) {
+  return JSON.stringify(methodChain) + divider + eventName
+}
+
+/**
+ * @param {string} string
+ * @returns {[MethodChain, string]}
+ */
+function parse(string) {
+  const [stringifiedMethodChain, eventName] = string.split(divider)
+  const methodChain = JSON.parse(stringifiedMethodChain)
+  if (!isValidMethodChain(methodChain)) {
+    throw new SyntaxError('Cannot parse, invalid method chain')
+  }
+  if (typeof eventName !== 'string') {
+    throw new SyntaxError('Cannot parse, invalid event name')
+  }
+  return [methodChain, eventName]
+}
+
+/**
+ * @param {unknown} maybeMethodChain
+ * @return {maybeMethodChain is MethodChain}
+ */
+function isValidMethodChain(maybeMethodChain) {
+  return (
+    Array.isArray(maybeMethodChain) &&
+    maybeMethodChain.every(
+      ([key, args]) =>
+        typeof key === 'string' &&
+        (typeof args === 'undefined' || Array.isArray(args))
+    )
+  )
+}
+
+/**
+ * Build a string for error message
+ *
+ * @param {MethodChain} methodChain
+ * @returns {string}
+ */
+function getMethodString(methodChain) {
+  if (methodChain.length === 0) return '[target]'
+  let result = ['[target]']
+  for (const [propertyKey, args] of methodChain.slice(0, -1)) {
+    if (Array.isArray(args)) {
+      result.push(
+        `${propertyKey}(${args.map((a) => JSON.stringify(a)).join(',')})`
+      )
+    } else result.push(propertyKey)
+  }
+  result.push(methodChain[methodChain.length - 1][0])
+  return result.join('.')
+}

--- a/lib/validate-message.js
+++ b/lib/validate-message.js
@@ -1,9 +1,9 @@
-const { isStringArray } = require('./prop-array-utils')
+const { isValidMethodChain } = require('./method-chain-utils')
 const { msgType } = require('./constants')
 const { types } = require('util')
-const isArrayLike = require('validate.io-array-like')
 
 /** @typedef {import("./types").Message} Message */
+/** @typedef {import("./types").MethodChain} MethodChain */
 
 const objectStreamSuggest =
   'Maybe the stream you are using is not in objectMode?'
@@ -28,11 +28,8 @@ module.exports = function isValidMessage(msg) {
     if (typeof msg[1] !== 'number') {
       invalid = `Invalid messageId of type ${typeof msg[1]} (was expecting a number). `
     }
-    if (!isStringArray(msg[2])) {
-      invalid += `Invalid prop array ${JSON.stringify(msg[2])}. `
-    }
-    if (!isArrayLike(msg[3])) {
-      invalid += `Invalid method arguments (must be an array-like object). `
+    if (!isValidMethodChain(msg[2])) {
+      invalid += `Invalid method chain ${JSON.stringify(msg[2])}. `
     }
   } else if (msg[0] === msgType.RESPONSE) {
     if (typeof msg[1] !== 'number') {
@@ -45,8 +42,8 @@ module.exports = function isValidMessage(msg) {
     if (typeof msg[1] !== 'string') {
       invalid = `Invalid eventName: ${msg[1]}. `
     }
-    if (!isStringArray(msg[2])) {
-      invalid += `Invalid prop array ${JSON.stringify(msg[2])}. `
+    if (!isValidMethodChain(msg[2])) {
+      invalid += `Invalid method chain ${JSON.stringify(msg[2])}. `
     }
     if (typeof msg[3] !== 'undefined' && typeof msg[3] !== 'object') {
       invalid += 'Expected an ErrorObject or null as the 3rd argument. '
@@ -58,8 +55,8 @@ module.exports = function isValidMessage(msg) {
     if (typeof msg[1] !== 'string') {
       invalid = `Invalid eventName: ${msg[1]}. `
     }
-    if (!isStringArray(msg[2])) {
-      invalid += `Invalid prop array ${JSON.stringify(msg[2])}. `
+    if (!isValidMethodChain(msg[2])) {
+      invalid += `Invalid method chain ${JSON.stringify(msg[2])}. `
     }
   } else {
     invalid = `Unhandled message type: ${msg[0]}. `

--- a/test/fixtures/invalid-messages.js
+++ b/test/fixtures/invalid-messages.js
@@ -5,7 +5,7 @@ module.exports = [
   [0, 'stringID'],
   [0, 7, 'stringMethodName'],
   [0, 7, ['stringMethodName']],
-  [0, 7, ['stringMethodName', 2], []],
+  [0, 7, ['stringMethodName', 2]],
   [0, 7],
   [1],
   [1, 'stringID'],

--- a/test/fixtures/valid-messages.js
+++ b/test/fixtures/valid-messages.js
@@ -1,8 +1,15 @@
-/** @type {import('../../lib/types').Message[]} */
-const validMessages = [
-  [0, 2, ['anyMethod'], []],
-  [0, 3, ['anyMethod'], ['param2', { other: 'param' }]],
-  [0, 3, ['anyMethod', 'nestedMethod'], ['param2', { other: 'param' }]],
+module.exports = [
+  [0, 2, [['anyMethod', []]]],
+  [0, 3, [['anyMethod', ['param2', { other: 'param' }]]]],
+  [
+    0,
+    3,
+    [
+      ['anyMethod', []],
+      ['nestedMethod', ['param2', { other: 'param' }]],
+    ],
+  ],
+  [0, 3, [['namespace'], ['nestedMethod', ['param2', { other: 'param' }]]]],
   [1, 4, null, 'returnedValue'],
   [1, 4, null, Buffer.from('returnedValue')],
   [1, 4, null, Buffer.from('returnedValue'), true],
@@ -10,10 +17,8 @@ const validMessages = [
   [1, 5, { message: 'Error message' }],
   [1, 6, null],
   [2, 'eventName', []],
-  [3, 'eventName', ['method']],
+  [3, 'eventName', [['method']]],
   [4, 'eventName', [], null, []],
-  [4, 'eventName', ['method'], null, ['param1', { other: 'param' }]],
+  [4, 'eventName', [['method']], null, ['param1', { other: 'param' }]],
   [4, 'eventName', [], { message: 'Error Message' }],
 ]
-
-module.exports = validMessages


### PR DESCRIPTION
This allows you to call a nested method on the server e.g.
client.myMethod().otherMethod()

This is only a proof-of-concept and will not yet work. Implementing this probably requires support for [Weak References and Finalizers](https://v8.dev/features/weak-references) that were added in Node v14.6.0+. They are needed because the server needs to keep a reference to the object returned by `client.myMethod()` for as long as the client does. E.g.

```js
const subClient = client.myMethod()
const result = await subClient.otherMethod()
```

We need a WeakRef to garbage collect `subClient` on the server when it is garbage collected on the client. Otherwise memory will grow on the server since we need to keep around any returned values forever.

It might be too difficult to implement this bug-free, it's probably better to avoid this pattern for an API that is going to be called over RPC.
