### PR TITLE
fix: Can await returned client

### DIFF
--- a/client.js
+++ b/client.js
@@ -197,6 +197,8 @@ function createClient(channel, { timeout = 5000 } = {}) {
         // }
         if (typeof prop !== 'string') {
           throw new Error(`ReferenceError: ${String(prop)} is not defined`)
+        } else if (prop === 'then') {
+          return null
         } else if (prop in EventEmitter.prototype) {
           const eventEmitterProp = /** @type {keyof EventEmitter} */ (prop)
           if (emitterSubscribeMethods.includes(eventEmitterProp)) {

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -550,4 +550,11 @@ function runTests(setup) {
     t.doesNotThrow(() => console.log(client.add(1, 2)))
     t.end()
   })
+
+  test('Can await client', async (t) => {
+    const { client } = setup(myApi)
+    const awaited = await client
+    t.is(awaited, client, 'Same object is returned when awaiting')
+    t.end()
+  })
 }


### PR DESCRIPTION
calling `await client` was throwing an error. The returned client should
not be thenable, and should just return the same client