### PR TITLE
fix: always return same object from client prop

### DIFF
--- a/client.js
+++ b/client.js
@@ -197,6 +197,8 @@ function createClient(channel, { timeout = 5000 } = {}) {
         // }
         if (typeof prop !== 'string') {
           throw new Error(`ReferenceError: ${String(prop)} is not defined`)
+        } else if (prop === 'then') {
+          return null
         } else if (prop in EventEmitter.prototype) {
           const eventEmitterProp = /** @type {keyof EventEmitter} */ (prop)
           if (emitterSubscribeMethods.includes(eventEmitterProp)) {

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -550,4 +550,11 @@ function runTests(setup) {
     t.doesNotThrow(() => console.log(client.add(1, 2)))
     t.end()
   })
+
+  test('Can await client', async (t) => {
+    const { client } = setup(myApi)
+    const awaited = await client
+    t.is(awaited, client, 'Same object is returned when awaiting')
+    t.end()
+  })
 }


### PR DESCRIPTION
Stacked on #17

There was a bug where every time you access a client property e.g.
`client.namespace` it would return a new Proxy object, which would lead
to unexpected behaviour when accessing a client object, e.g.
`client.namespace === client.namespace` would be false. It would also
cause a lot of garbage collection slowing things down (all those Proxy
objects need to be garbage collected).

This fix caches all the sub clients that are created when you access
properties. This could be seen as a memory leak because every time you
access a client property, the value is cached, but this is effectively
lazily building the API on the server side - as long as you don't call
huge numbers of non-existent properties on the client it won't take much
more memory than the server-side API.