### PR TITLE
fix: fix compatibility with verbatimModuleSyntax TS config option

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,6 @@
 import type { ErrorObject } from 'serialize-error'
-import { EventEmitter } from 'events'
-import { Readable } from 'stream'
+import type { EventEmitter } from 'events'
+import type { Readable } from 'stream'
 
 export enum msgType {
   REQUEST = 0,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-import { ErrorObject } from 'serialize-error'
+import type { ErrorObject } from 'serialize-error'
 import { EventEmitter } from 'events'
 import { Readable } from 'stream'
 


### PR DESCRIPTION
Currently trying to build a library that imports types from this module and emits its own declarations. However, running TS on it fails when the [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) option is enabled on my project:

```sh
node_modules/rpc-reflector/lib/types.ts:1:10 - error TS1484: 'ErrorObject' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.

1 import { ErrorObject } from 'serialize-error'
           ~~~~~~~~~~~


Found 1 error in node_modules/rpc-reflector/lib/types.ts:1
```

There doesn't seem to be any downside to convert the import in question to an explicit type-only import, which I believe is generally recommended when possible anyways when working with TypeScript.

I didn't update the other imports in this file since that first one was the only one that caused the error. Open to fixing the other imports in this PR if it makes sense to.