### PR TITLE
fix: another fix for compatability with verbatimModuleSyntax config option

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,13 +2,7 @@ import type { ErrorObject } from 'serialize-error'
 import type { EventEmitter } from 'events'
 import type { Readable } from 'stream'
 
-export enum msgType {
-  REQUEST = 0,
-  RESPONSE = 1,
-  ON = 2,
-  OFF = 3,
-  EMIT = 4,
-}
+import type { msgType } from './constants'
 
 export interface test {
   foo: boolean


### PR DESCRIPTION
Similar to #20 , as I was running into the following TS error when having `verbatimModuleSyntax: true`

```sh
ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.
```

Tested this patch on the repo I'm working with and it seemed to eliminate the type error. As far as I understand, the exported enum is not actually used a value anywhere (there's a similar constant defined in `lib/constants.js` that's used in the source code)