### PR TITLE
feat: add logger option

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,12 +1,13 @@
 import { EventEmitter } from 'eventemitter3'
-import { invariant } from './invariant.js'
+import { ExhaustivenessError, invariant } from './utils.js'
 import { deserializeError } from 'serialize-error'
 import promiseTimeout from 'p-timeout'
 
 import { isMessagePortLike } from './is-message-port-like.js'
 import { msgType } from './constants.js'
 import { stringify, parse } from './prop-array-utils.js'
-import { isValidMessage } from './validate-message.js'
+import { validateResponseMsg } from './validate-message.js'
+import nullLogger from 'abstract-logging'
 
 /** @typedef {import('./types.js').MsgRequest} MsgRequest */
 /** @typedef {import('./types.js').MsgResponse} MsgResponse */
@@ -40,15 +41,17 @@ const closeProp = Symbol('close')
  * listens to replies from the server via `receiver`.
  *
  * @param {MessagePort | MessagePortLike | MessagePortNode} channel MessagePort-like object that must implement an `.on('message')` event handler and a `.postMessage()` method.
- * @param {{timeout?: number}} options Optionally set timeout (default 5000)
- *
+ * @param {object} [options] Options object
+ * @param {number} [options.timeout=5000] Optionally set timeout (default 5000)
+ * @param {false | Omit<import('pino').BaseLogger, 'level' | 'silent'>} [options.logger = false] options.logger Set to `false` to disable logging, or pass a pino logger instance to enable logging
  * @returns {ClientApi<ApiType>}
  */
-export function createClient(channel, { timeout = 5000 } = {}) {
+export function createClient(channel, { timeout = 5000, logger = false } = {}) {
   invariant(
     isMessagePortLike(channel),
     'Must pass a browser MessagePort, node worker.MessagePort, or MessagePort-like object',
   )
+  const log = logger || nullLogger
   let id = 0
   /** @type {Map<number, [(value?: any) => void, (reason?: any) => void]>} */
   const pending = new Map() // Messages pending response
@@ -78,16 +81,22 @@ export function createClient(channel, { timeout = 5000 } = {}) {
     if (typeof msg === 'object' && msg && 'data' in msg) {
       msg = msg.data
     }
-    if (!isValidMessage(msg)) return
+    try {
+      validateResponseMsg(msg)
+    } catch (err) {
+      log.warn(
+        { err, rpcMsg: msg },
+        'Received invalid message. (Message was ignored)',
+      )
+      return
+    }
     switch (msg[0]) {
       case msgType.RESPONSE:
         return handleResponse(/** @type {MsgResponse} */ (msg))
       case msgType.EMIT:
         return handleEmit(/** @type {MsgEmit} */ (msg))
       default:
-        console.warn(
-          `Received unexpected message type: ${msg[0]}. (Message was ignored)`,
-        )
+        new ExhaustivenessError(msg[0])
     }
   }
 
@@ -95,9 +104,8 @@ export function createClient(channel, { timeout = 5000 } = {}) {
   function handleResponse([, msgId, errorObject, value, more, objectMode]) {
     const resolveReject = pending.get(msgId)
     if (!resolveReject) {
-      return console.warn(
-        `Received unknown message ID: ${msgId}. (Message was ignored)`,
-      )
+      log.warn({ msgId }, 'Received unknown message ID (ignored)')
+      return
     }
     const [resolve, reject] = resolveReject
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -96,7 +96,7 @@ export function createClient(channel, { timeout = 5000, logger = false } = {}) {
       case msgType.EMIT:
         return handleEmit(/** @type {MsgEmit} */ (msg))
       default:
-        new ExhaustivenessError(msg[0])
+        throw new ExhaustivenessError(msg[0])
     }
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,9 +1,9 @@
-import { invariant } from './invariant.js'
+import { ExhaustivenessError, invariant } from './utils.js'
 import { serializeError } from 'serialize-error'
-
+import nullLogger from 'abstract-logging'
 import { isDuplexStream, isReadableStream } from 'is-stream'
 import { msgType } from './constants.js'
-import { isValidMessage } from './validate-message.js'
+import { validateRequestMsg } from './validate-message.js'
 import { parse, stringify } from './prop-array-utils.js'
 import { MessageStream } from './message-stream.js'
 import { isMessagePortLike } from './is-message-port-like.js'
@@ -30,12 +30,14 @@ import ensureError from 'ensure-error'
  * or a ReadableStream. Your transport stream must be able to encode/decode any
  * values that your handler returns
  * @param {MessagePort | MessagePortLike | MessagePortNode | import('stream').Duplex} channel A Duplex Stream with objectMode=true or a MessagePort-like object that must implement an `.on('message')` event handler and a `.postMessage()` method.
- *
+ * @param {object} [options] Options object
+ * @param {false | Omit<import('pino').BaseLogger, 'level' | 'silent'>} [options.logger = false] options.logger Set to `false` to disable logging, or pass a pino logger instance to enable logging
  * @returns {{ close: () => void }} An object with a single method `close()`
  * that will stop the server listening to and sending any more messages
  */
-export function createServer(handler, channel) {
+export function createServer(handler, channel, { logger = false } = {}) {
   invariant(typeof handler === 'object', 'Missing handler object.')
+  const log = logger || nullLogger
   const channelIsStream = isDuplexStream(channel)
   invariant(
     isMessagePortLike(channel) || channelIsStream,
@@ -75,16 +77,21 @@ export function createServer(handler, channel) {
     if (typeof msg === 'object' && msg && 'data' in msg) {
       msg = msg.data
     }
-    if (!isValidMessage(msg)) return
+    try {
+      validateRequestMsg(msg)
+    } catch (err) {
+      log.warn({ err, rpcMsg: msg }, 'Invalid RPC message received (ignored)')
+      return
+    }
     switch (msg[0]) {
       case msgType.REQUEST:
-        return handleRequest(/** @type {MsgRequest} */ (msg))
+        return handleRequest(msg)
       case msgType.ON:
-        return handleOn(/** @type {MsgOn} */ (msg))
+        return handleOn(msg)
       case msgType.OFF:
-        return handleOff(/** @type {MsgOff} */ (msg))
+        return handleOff(msg)
       default:
-        console.warn(`Unhandled message type: ${msg[0]}. (Message was ignored)`)
+        throw new ExhaustivenessError(msg[0])
     }
   }
 
@@ -126,8 +133,12 @@ export function createServer(handler, channel) {
     let emitter
     try {
       emitter = getNestedEventEmitter(handler, propArray)
-    } catch (e) {
-      return console.warn(e + '. (Subscription from client was ignored)')
+    } catch (err) {
+      log.warn(
+        { err, eventName, propArray },
+        'Error subscribing to event (ignored)',
+      )
+      return
     }
 
     const encodedEventName = stringify(propArray, eventName)
@@ -152,8 +163,12 @@ export function createServer(handler, channel) {
     let emitter
     try {
       emitter = getNestedEventEmitter(handler, propArray)
-    } catch (e) {
-      return console.warn(e + '. (Subscription from client was ignored)')
+    } catch (err) {
+      log.warn(
+        { err, eventName, propArray },
+        'Error unsubscribing from event (ignored)',
+      )
+      return
     }
 
     const encodedEventName = stringify(propArray, eventName)

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,47 +10,47 @@ export interface test {
 
 export type NonEmptyArray<T> = [T, ...T[]]
 
-type msgId = number
-type prop = string
-type eventName = string
-type args = Array<any>
-type params = Array<any>
-type result = any
-type more = boolean
-type isObjectMode = boolean
+export type MsgId = number
+type Prop = string
+type EventName = string
+type Args = Array<any>
+type Params = Array<any>
+type Result = any
+type More = boolean
+type IsObjectMode = boolean
 
 export type MsgRequest = [
   typeof msgType.REQUEST,
-  msgId,
-  NonEmptyArray<prop>,
-  args,
+  MsgId,
+  NonEmptyArray<Prop>,
+  Args,
 ]
 // The last message in a streaming request
 type MsgResponseEnd = [
   typeof msgType.RESPONSE,
-  msgId,
+  MsgId,
   ErrorObject | null,
-  result,
+  Result,
   false, // More data to come?
-  isObjectMode, // Last message in streaming response indicates if was objectMode
+  IsObjectMode, // Last message in streaming response indicates if was objectMode
 ]
 export type MsgResponse =
   | [
       typeof msgType.RESPONSE,
-      msgId, // messageId
+      MsgId, // messageId
       ErrorObject | null, // error
-      result?, // result
-      more?, // more data to come?
+      Result?, // result
+      More?, // more data to come?
     ]
   | MsgResponseEnd
-export type MsgOn = [typeof msgType.ON, eventName, Array<prop>]
-export type MsgOff = [typeof msgType.OFF, eventName, Array<prop>]
+export type MsgOn = [typeof msgType.ON, EventName, Array<Prop>]
+export type MsgOff = [typeof msgType.OFF, EventName, Array<Prop>]
 export type MsgEmit = [
   typeof msgType.EMIT,
-  eventName,
-  Array<prop>,
+  EventName,
+  Array<Prop>,
   ErrorObject | null,
-  params?,
+  Params?,
 ]
 export type Message = MsgRequest | MsgResponse | MsgOn | MsgOff | MsgEmit
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,3 +17,11 @@ export function invariant(condition, message) {
   const value = provided ? `${prefix}: ${provided}` : prefix
   throw new Error(value)
 }
+
+export class ExhaustivenessError extends Error {
+  /** @param {never} value */
+  constructor(value) {
+    super(`Exhaustiveness check failed. ${value} should be impossible`)
+    this.name = 'ExhaustivenessError'
+  }
+}

--- a/lib/validate-message.js
+++ b/lib/validate-message.js
@@ -1,80 +1,128 @@
 import { isStringArray } from './prop-array-utils.js'
 import { msgType } from './constants.js'
 
-/** @typedef {import("./types.js").Message} Message */
-
+/** @import {MsgRequest, MsgOn, MsgOff, MsgResponse, MsgEmit, MsgId} from './types.js' */
 const objectStreamSuggest =
   'Maybe the stream you are using is not in objectMode?'
 
 /**
- * Checks if a RPC message is valid
  *
  * @param {unknown} msg
- * @returns {msg is Message} Returns a boolean indicating if message is valid
+ * @returns {asserts msg is [number, ...any[]]}
  */
-export function isValidMessage(msg) {
-  let invalid = ''
+function validateMsgArray(msg) {
   if (!Array.isArray(msg)) {
-    if (typeof msg === 'string') {
-      invalid = `Received a string (expected an array). ${objectStreamSuggest} `
-    } else if (ArrayBuffer.isView(msg)) {
-      invalid = `Received an ArrayBuffer (expected an array). ${objectStreamSuggest} `
-    } else {
-      invalid = `Invalid message of type '${typeof msg}' (was expecting an array). `
-    }
-  } else if (msg[0] === msgType.REQUEST) {
-    if (typeof msg[1] !== 'number') {
-      invalid = `Invalid messageId of type ${typeof msg[1]} (was expecting a number). `
-    }
-    if (!isStringArray(msg[2])) {
-      invalid += `Invalid prop array ${JSON.stringify(msg[2])}. `
-    }
-    if (!Array.isArray(msg[3])) {
-      invalid += `Invalid method arguments (must be an array). `
-    }
-  } else if (msg[0] === msgType.RESPONSE) {
-    if (typeof msg[1] !== 'number') {
-      invalid = `Invalid messageId of type ${typeof msg[1]} (was expecting a number). `
-    }
-    if (typeof msg[2] !== 'undefined' && typeof msg[2] !== 'object') {
-      invalid += 'Expected an ErrorObject or null as the 3rd argument. '
-    }
-  } else if (msg[0] === msgType.EMIT) {
-    if (typeof msg[1] !== 'string') {
-      invalid = `Invalid eventName: ${msg[1]}. `
-    }
-    if (!isStringArray(msg[2])) {
-      invalid += `Invalid prop array ${JSON.stringify(msg[2])}. `
-    }
-    if (typeof msg[3] !== 'undefined' && typeof msg[3] !== 'object') {
-      invalid += 'Expected an ErrorObject or null as the 3rd argument. '
-    }
-    if (typeof msg[4] !== 'undefined' && !Array.isArray(msg[4])) {
-      invalid += `Invalid returned params for EMIT: got ${msg[4]} expected an Array of JSON objects. `
-    }
-  } else if (msg[0] === msgType.ON || msg[0] === msgType.OFF) {
-    if (typeof msg[1] !== 'string') {
-      invalid = `Invalid eventName: ${msg[1]}. `
-    }
-    if (!isStringArray(msg[2])) {
-      invalid += `Invalid prop array ${JSON.stringify(msg[2])}. `
-    }
-  } else {
-    invalid = `Unhandled message type: ${msg[0]}. `
-  }
-
-  if (
-    invalid &&
-    typeof process !== 'undefined' &&
-    'env' in process &&
-    process.env.NODE_ENV !== 'production'
-  ) {
-    console.warn(
-      invalid +
-        '(Message was ignored)\n' +
-        'Message was: ' +
-        JSON.stringify(msg),
+    const msgType = ArrayBuffer.isView(msg) ? 'ArrayBuffer' : typeof msg
+    throw new TypeError(
+      `Invalid message of type '${msgType}' (was expecting an array). ${objectStreamSuggest}`,
     )
   }
-  return !invalid
+  if (msg.length === 0) {
+    throw new Error('Received an empty message array.')
+  }
+  if (typeof msg[0] !== 'number') {
+    throw new TypeError(
+      `Expected the first element to be a number, but received a ${typeof msg[0]}.`,
+    )
+  }
+}
+
+/**
+ * @param {unknown} msg
+ * @returns {asserts msg is MsgRequest | MsgOn | MsgOff}
+ */
+export function validateRequestMsg(msg) {
+  validateMsgArray(msg)
+  const errors = []
+
+  switch (msg[0]) {
+    case msgType.REQUEST:
+      if (typeof msg[1] !== 'number') {
+        errors.push(
+          new TypeError(
+            `Invalid messageId of type ${typeof msg[1]} (was expecting a number).`,
+          ),
+        )
+      }
+      if (!isStringArray(msg[2])) {
+        errors.push(
+          new TypeError(`Invalid prop array ${JSON.stringify(msg[2])}.`),
+        )
+      }
+      if (!Array.isArray(msg[3])) {
+        errors.push(
+          new TypeError(`Invalid method arguments (must be an array).`),
+        )
+      }
+      break
+    case msgType.ON:
+    case msgType.OFF:
+      if (typeof msg[1] !== 'string') {
+        errors.push(new Error(`Invalid eventName: ${msg[1]}. `))
+      }
+      if (!isStringArray(msg[2])) {
+        errors.push(
+          new TypeError(`Invalid prop array ${JSON.stringify(msg[2])}. `),
+        )
+      }
+      break
+    default:
+      throw new Error(`Unhandled message type: ${msg[0]}.`)
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, 'Invalid request message')
+  }
+}
+
+/**
+ * @param {unknown} msg
+ * @returns {asserts msg is MsgResponse | MsgEmit}
+ */
+export function validateResponseMsg(msg) {
+  validateMsgArray(msg)
+  const errors = []
+
+  switch (msg[0]) {
+    case msgType.RESPONSE:
+      if (typeof msg[1] !== 'number') {
+        errors.push(
+          new TypeError(
+            `Invalid messageId of type ${typeof msg[1]} (was expecting a number).`,
+          ),
+        )
+      }
+      if (typeof msg[2] !== 'undefined' && typeof msg[2] !== 'object') {
+        errors.push(
+          new Error('Expected an ErrorObject or null as the 3rd argument.`'),
+        )
+      }
+      break
+    case msgType.EMIT:
+      if (typeof msg[1] !== 'string') {
+        errors.push(new TypeError(`Invalid eventName: ${msg[1]}.`))
+      }
+      if (!isStringArray(msg[2])) {
+        errors.push(
+          new TypeError(`Invalid prop array ${JSON.stringify(msg[2])}.`),
+        )
+      }
+      if (typeof msg[3] !== 'undefined' && typeof msg[3] !== 'object') {
+        errors.push(
+          new TypeError('Expected an ErrorObject or null as the 3rd argument.'),
+        )
+      }
+      if (typeof msg[4] !== 'undefined' && !Array.isArray(msg[4])) {
+        errors.push(
+          new TypeError(
+            `Invalid returned params for EMIT: got ${msg[4]} expected an Array of JSON objects.`,
+          ),
+        )
+      }
+      break
+    default:
+      throw new Error(`Unhandled message type: ${msg[0]}.`)
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, 'Invalid response message')
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/node": "^18.19.115",
+        "abstract-logging": "^2.0.1",
         "ensure-error": "^4.0.0",
         "eventemitter3": "^5.0.1",
         "is-stream": "^4.0.1",
@@ -26,6 +27,8 @@
         "globals": "^16.3.0",
         "husky": "^9.1.7",
         "into-stream": "^8.0.1",
+        "pino": "^9.7.0",
+        "pino-pretty": "^13.0.0",
         "prettier": "^3.6.2",
         "rimraf": "^5.0.10",
         "tape": "^5.9.0",
@@ -442,6 +445,12 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -572,6 +581,16 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -784,6 +803,13 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -859,6 +885,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -996,6 +1032,16 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/ensure-error": {
       "version": "4.0.0",
@@ -1384,6 +1430,13 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1401,6 +1454,23 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -1772,6 +1842,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -2346,6 +2423,16 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2569,6 +2656,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2720,6 +2817,71 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pino": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
+      "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.0.0.tgz",
+      "integrity": "sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.2",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -2761,6 +2923,34 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2769,6 +2959,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "4.7.0",
@@ -2783,6 +2980,16 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -2973,6 +3180,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -3148,6 +3372,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -3428,6 +3672,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/node": "^18.19.115",
+    "abstract-logging": "^2.0.1",
     "ensure-error": "^4.0.0",
     "eventemitter3": "^5.0.1",
     "is-stream": "^4.0.1",
@@ -50,6 +51,8 @@
     "globals": "^16.3.0",
     "husky": "^9.1.7",
     "into-stream": "^8.0.1",
+    "pino": "^9.7.0",
+    "pino-pretty": "^13.0.0",
     "prettier": "^3.6.2",
     "rimraf": "^5.0.10",
     "tape": "^5.9.0",

--- a/test/fixtures/valid-messages.js
+++ b/test/fixtures/valid-messages.js
@@ -1,19 +1,23 @@
-/** @type {import('../../lib/types.js').Message[]} */
-const validMessages = [
+/** @import {MsgRequest, MsgOn, MsgOff, MsgResponse, MsgEmit, MsgId} from '../../lib/types.js' */
+
+/** @type {Array<MsgRequest | MsgOn | MsgOff>} */
+export const validRequestMessages = [
   [0, 2, ['anyMethod'], []],
   [0, 3, ['anyMethod'], ['param2', { other: 'param' }]],
   [0, 3, ['anyMethod', 'nestedMethod'], ['param2', { other: 'param' }]],
+  [2, 'eventName', []],
+  [3, 'eventName', ['method']],
+]
+
+/** @type {Array<MsgResponse | MsgEmit>} */
+export const validResponseMessages = [
   [1, 4, null, 'returnedValue'],
   [1, 4, null, Buffer.from('returnedValue')],
   [1, 4, null, Buffer.from('returnedValue'), true],
   [1, 4, null, null, false, true],
   [1, 5, { message: 'Error message' }],
   [1, 6, null],
-  [2, 'eventName', []],
-  [3, 'eventName', ['method']],
   [4, 'eventName', [], null, []],
   [4, 'eventName', ['method'], null, ['param1', { other: 'param' }]],
   [4, 'eventName', [], { message: 'Error Message' }],
 ]
-
-export default validMessages

--- a/test/invariant.test.js
+++ b/test/invariant.test.js
@@ -1,5 +1,5 @@
 import test from 'tape'
-import { invariant } from '../lib/invariant.js'
+import { invariant } from '../lib/utils.js'
 
 test('invariant', (t) => {
   t.throws(() => invariant(false), 'Throws when condition is false')

--- a/test/validate-message.test.js
+++ b/test/validate-message.test.js
@@ -1,19 +1,37 @@
 import test from 'tape'
-import { isValidMessage } from '../lib/validate-message.js'
-import validMessages from './fixtures/valid-messages.js'
+import {
+  validateRequestMsg,
+  validateResponseMsg,
+} from '../lib/validate-message.js'
+import {
+  validRequestMessages,
+  validResponseMessages,
+} from './fixtures/valid-messages.js'
 import invalidMessages from './fixtures/invalid-messages.js'
 
 test('Valid messages return true', (t) => {
-  for (const msg of validMessages) {
-    t.ok(isValidMessage(msg), `Message \`${JSON.stringify(msg)}\` is valid`)
+  for (const msg of validRequestMessages) {
+    t.doesNotThrow(
+      () => validateRequestMsg(msg),
+      `Message \`${JSON.stringify(msg)}\` is valid`,
+    )
+  }
+  for (const msg of validResponseMessages) {
+    t.doesNotThrow(
+      () => validateResponseMsg(msg),
+      `Message \`${JSON.stringify(msg)}\` is valid`,
+    )
   }
   t.end()
 })
 
 test('Invalid mesages return false', (t) => {
   for (const msg of invalidMessages) {
-    t.false(
-      isValidMessage(msg),
+    t.throws(
+      () => {
+        validateRequestMsg(msg)
+        validateResponseMsg(msg)
+      },
       `Message \`${JSON.stringify(msg)}\` is invalid`,
     )
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "forceConsistentCasingInFileNames": true,
 
     "skipLibCheck": true,
-    "rootDir": "."
+    "rootDir": ".",
+    "typeRoots": ["types", "node_modules/@types"]
   },
   "include": ["**/*"],
   "exclude": ["node_modules"]

--- a/types/abstract-logging.d.ts
+++ b/types/abstract-logging.d.ts
@@ -1,0 +1,13 @@
+declare module 'abstract-logging' {
+  type LogFunction = (...args: any[]) => void
+  interface AbstractLogger {
+    trace: LogFunction
+    debug: LogFunction
+    info: LogFunction
+    warn: LogFunction
+    error: LogFunction
+    fatal: LogFunction
+  }
+  const nullLogger: AbstractLogger
+  export default nullLogger
+}


### PR DESCRIPTION
Supports passing a logger that implements the pino interface. For improved debug of rpc message errors.

This will be useful for Sentry reporting, but also is also a practice for implementing structured logging in comapeo core.