### PR TITLE
feat: add onRequestHook option

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -8,7 +8,9 @@ import { msgType } from './constants.js'
 import { stringify, parse } from './prop-array-utils.js'
 import { validateResponseMsg } from './validate-message.js'
 import nullLogger from 'abstract-logging'
+import pDefer from 'p-defer'
 
+/** @import {MessageContainer, MsgRequestObj} from './types.js' */
 /** @typedef {import('./types.js').MsgRequest} MsgRequest */
 /** @typedef {import('./types.js').MsgResponse} MsgResponse */
 /** @typedef {import('./types.js').MsgOn} MsgOn */
@@ -44,9 +46,13 @@ const closeProp = Symbol('close')
  * @param {object} [options] Options object
  * @param {number} [options.timeout=5000] Optionally set timeout (default 5000)
  * @param {false | Omit<import('pino').BaseLogger, 'level' | 'silent'>} [options.logger = false] options.logger Set to `false` to disable logging, or pass a pino logger instance to enable logging
+ * @param {(request: Omit<MsgRequestObj, 'metadata'>, next: (request: MsgRequestObj) => Promise<any>) => void} [options.onRequestHook] Optional hook to observe and modify a request and its metadata, and to await the response.
  * @returns {ClientApi<ApiType>}
  */
-export function createClient(channel, { timeout = 5000, logger = false } = {}) {
+export function createClient(
+  channel,
+  { timeout = 5000, logger = false, onRequestHook } = {},
+) {
   invariant(
     isMessagePortLike(channel),
     'Must pass a browser MessagePort, node worker.MessagePort, or MessagePort-like object',
@@ -65,9 +71,38 @@ export function createClient(channel, { timeout = 5000, logger = false } = {}) {
     channel.addEventListener('message', handleMessage)
   }
 
-  /** @param {MsgRequest | MsgOn | MsgOff} msg */
+  /** @param {MsgRequest | MsgOn | MsgOff | MessageContainer} msg */
   function send(msg) {
     channel.postMessage(msg)
+  }
+
+  /**
+   * @param {MsgRequestObj} request
+   * @param {Promise<any>} resultPromise
+   */
+  function sendRequest({ msgId, method, args }, resultPromise) {
+    if (onRequestHook) {
+      onRequestHook({ msgId, method, args }, (modifiedRequest) => {
+        sendModifiedRequest(modifiedRequest)
+        return resultPromise
+      })
+    } else {
+      send([msgType.REQUEST, msgId, method, args])
+    }
+  }
+
+  /**
+   * @param {MsgRequestObj} request
+   * @returns
+   */
+  function sendModifiedRequest({ msgId, method, args, metadata }) {
+    /** @type {MsgRequest} */
+    const msg = [msgType.REQUEST, msgId, method, args]
+    if (metadata) {
+      send({ value: msg, metadata })
+    } else {
+      send(msg)
+    }
   }
 
   /**
@@ -258,12 +293,9 @@ export function createClient(channel, { timeout = 5000, logger = false } = {}) {
         }
         const msgId = id++
 
-        const pendingResult = new Promise((resolve, reject) => {
-          pending.set(msgId, [resolve, reject])
-          send([msgType.REQUEST, msgId, propArray, args])
-        })
-
-        return promiseTimeout(pendingResult, {
+        const { resolve, reject, promise } = pDefer()
+        pending.set(msgId, [resolve, reject])
+        const resultPromiseWithTimeout = promiseTimeout(promise, {
           milliseconds: timeout,
           fallback() {
             // Cleanup pending handlers because they will never be called now
@@ -272,6 +304,11 @@ export function createClient(channel, { timeout = 5000, logger = false } = {}) {
             The server could be closed or the transport is down.`)
           },
         })
+        sendRequest(
+          { msgId, method: propArray, args },
+          resultPromiseWithTimeout,
+        )
+        return resultPromiseWithTimeout
       },
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,13 +3,14 @@ import { serializeError } from 'serialize-error'
 import nullLogger from 'abstract-logging'
 import { isDuplexStream, isReadableStream } from 'is-stream'
 import { msgType } from './constants.js'
-import { validateRequestMsg } from './validate-message.js'
+import { validateMetadata, validateRequestMsg } from './validate-message.js'
 import { parse, stringify } from './prop-array-utils.js'
 import { MessageStream } from './message-stream.js'
 import { isMessagePortLike } from './is-message-port-like.js'
 import { EventEmitter } from 'events'
 import ensureError from 'ensure-error'
 
+/** @import {MsgRequestObj, Result, Metadata, MsgId} from './types.js'*/
 /** @typedef {import('./types.js').MsgRequest} MsgRequest */
 /** @typedef {import('./types.js').MsgResponse} MsgResponse */
 /** @typedef {import('./types.js').MsgOn} MsgOn */
@@ -32,10 +33,14 @@ import ensureError from 'ensure-error'
  * @param {MessagePort | MessagePortLike | MessagePortNode | import('stream').Duplex} channel A Duplex Stream with objectMode=true or a MessagePort-like object that must implement an `.on('message')` event handler and a `.postMessage()` method.
  * @param {object} [options] Options object
  * @param {false | Omit<import('pino').BaseLogger, 'level' | 'silent'>} [options.logger = false] options.logger Set to `false` to disable logging, or pass a pino logger instance to enable logging
- * @returns {{ close: () => void }} An object with a single method `close()`
- * that will stop the server listening to and sending any more messages
+ * @param {(request: MsgRequestObj, next: (request: Omit<MsgRequestObj, 'metadata'>) => Result) => void} [options.onRequestHook] Optional hook to observe and modify a request and its metadata, and to await the response.
+ * @returns {{ close: () => void }} An object with a single method `close()` that will stop the server listening to and sending any more messages
  */
-export function createServer(handler, channel, { logger = false } = {}) {
+export function createServer(
+  handler,
+  channel,
+  { logger = false, onRequestHook } = {},
+) {
   invariant(typeof handler === 'object', 'Missing handler object.')
   const log = logger || nullLogger
   const channelIsStream = isDuplexStream(channel)
@@ -68,14 +73,49 @@ export function createServer(handler, channel, { logger = false } = {}) {
 
   /**
    * Handles an incoming message.
-   * @param {unknown} msg Can be any type, but we only process messages types that
+   * @param {unknown} messageContainer Can be any type, but we only process messages types that
    * we understand, other messages are ignored
    */
-  function handleMessage(msg) {
+  function handleMessage(messageContainer) {
+    /** @type {unknown} */
+    let msg
+    /** @type {Metadata | undefined} */
+    let metadata
+
     // When using a MessagePort in a browser or electron environment, the
     // actual data is in `event.data`
-    if (typeof msg === 'object' && msg && 'data' in msg) {
-      msg = msg.data
+    if (
+      typeof messageContainer === 'object' &&
+      messageContainer &&
+      'data' in messageContainer
+    ) {
+      messageContainer = messageContainer.data
+    }
+
+    // If the message is a MessageContainer, we extract the value and metadata
+    if (Array.isArray(messageContainer)) {
+      msg = messageContainer
+    } else if (
+      typeof messageContainer === 'object' &&
+      messageContainer !== null
+    ) {
+      if ('value' in messageContainer) {
+        msg = messageContainer.value
+      }
+      if (
+        'metadata' in messageContainer &&
+        messageContainer.metadata !== undefined
+      ) {
+        try {
+          validateMetadata(messageContainer.metadata)
+          metadata = messageContainer.metadata
+        } catch (err) {
+          log.warn(
+            { err, rpcMetadata: messageContainer.metadata },
+            'Invalid RPC metadata received (ignored)',
+          )
+        }
+      }
     }
     try {
       validateRequestMsg(msg)
@@ -83,49 +123,95 @@ export function createServer(handler, channel, { logger = false } = {}) {
       log.warn({ err, rpcMsg: msg }, 'Invalid RPC message received (ignored)')
       return
     }
+
     switch (msg[0]) {
       case msgType.REQUEST:
-        return handleRequest(msg)
+        {
+          const request = {
+            msgId: msg[1],
+            method: msg[2],
+            args: msg[3],
+            metadata,
+          }
+          if (onRequestHook) {
+            try {
+              onRequestHook(request, handleRequest)
+            } catch (err) {
+              log.error({ err, request }, 'Error in onRequestHook (ignored)')
+              // If the hook throws, we just handle the request directly
+              handleRequest(request)
+            }
+          } else {
+            handleRequest(request)
+          }
+        }
+        break
       case msgType.ON:
-        return handleOn(msg)
+        handleOn(msg)
+        break
       case msgType.OFF:
-        return handleOff(msg)
+        handleOff(msg)
+        break
       default:
         throw new ExhaustivenessError(msg[0])
     }
   }
 
-  /** @param {MsgRequest} msg */
-  async function handleRequest([, msgId, propArray, args]) {
-    /** @type {MsgResponse} */
-    let response
-
+  /**
+   * @param {MsgRequestObj} request
+   * @returns {Result}
+   */
+  function handleRequest({ msgId, method, args }) {
+    let syncResult
     try {
-      const result = await Promise.resolve(
-        applyNestedMethod(handler, propArray, args),
-      )
-      if (isReadableStream(result)) {
-        return handleStream(result)
-      }
-      response = [msgType.RESPONSE, msgId, null, result]
+      syncResult = applyNestedMethod(handler, method, args)
     } catch (error) {
-      response = [msgType.RESPONSE, msgId, serializeError(ensureError(error))]
+      send([msgType.RESPONSE, msgId, serializeError(ensureError(error))])
+      const resultPromise = Promise.reject(error)
+      resultPromise.catch(noop)
+      return resultPromise
     }
 
-    send(response)
+    if (isReadableStream(syncResult)) {
+      handleStream(msgId, syncResult)
+      return syncResult
+    }
 
-    /** @param {import('stream').Readable} stream */
-    function handleStream(stream) {
-      const rs = stream.pipe(new MessageStream(msgId))
-      if (channelIsStream) {
-        rs.pipe(channel, { end: false })
-      } else {
-        rs.on('data', (chunk) => send(chunk))
+    // This is done with Promise.then rather than an async function so that we
+    // can synchronously return a stream (above).
+    const resultPromise = Promise.resolve(syncResult).then((result) => {
+      if (isReadableStream(result)) {
+        handleStream(msgId, result)
+        return result
       }
-      rs.on('error', (err) =>
-        send([msgType.RESPONSE, msgId, serializeError(err)]),
-      )
+      send([msgType.RESPONSE, msgId, null, result])
+      return result
+    })
+
+    // resultPromise itself should be returned uncaught, so that the
+    // onRequestHook can observe the error. Having the catch here avoids an
+    // uncaught error if the onRequestHook does not attach a catch handler.
+    resultPromise.catch((error) => {
+      send([msgType.RESPONSE, msgId, serializeError(ensureError(error))])
+    })
+
+    return resultPromise
+  }
+
+  /**
+   * @param {MsgId} msgId
+   * @param {import('stream').Readable} stream
+   */
+  function handleStream(msgId, stream) {
+    const rs = stream.pipe(new MessageStream(msgId))
+    if (channelIsStream) {
+      rs.pipe(channel, { end: false })
+    } else {
+      rs.on('data', (chunk) => send(chunk))
     }
+    rs.on('error', (err) =>
+      send([msgType.RESPONSE, msgId, serializeError(err)]),
+    )
   }
 
   /** @param {MsgOn} msg */
@@ -266,3 +352,4 @@ function getNestedEventEmitter(target, propArray) {
   }
   return nested
 }
+function noop() {}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,11 +11,10 @@ export interface test {
 export type NonEmptyArray<T> = [T, ...T[]]
 
 export type MsgId = number
-type Prop = string
+export type Prop = string
 type EventName = string
-type Args = Array<any>
+export type Args = Array<any>
 type Params = Array<any>
-type Result = any
 type More = boolean
 type IsObjectMode = boolean
 
@@ -30,7 +29,7 @@ type MsgResponseEnd = [
   typeof msgType.RESPONSE,
   MsgId,
   ErrorObject | null,
-  Result,
+  any,
   false, // More data to come?
   IsObjectMode, // Last message in streaming response indicates if was objectMode
 ]
@@ -38,10 +37,11 @@ export type MsgResponse =
   | [
       typeof msgType.RESPONSE,
       MsgId, // messageId
-      ErrorObject | null, // error
-      Result?, // result
+      null, // error
+      any, // result
       More?, // more data to come?
     ]
+  | [typeof msgType.RESPONSE, MsgId, ErrorObject]
   | MsgResponseEnd
 export type MsgOn = [typeof msgType.ON, EventName, Array<Prop>]
 export type MsgOff = [typeof msgType.OFF, EventName, Array<Prop>]
@@ -53,6 +53,11 @@ export type MsgEmit = [
   Params?,
 ]
 export type Message = MsgRequest | MsgResponse | MsgOn | MsgOff | MsgEmit
+
+export type MessageContainer = {
+  value: Message
+  metadata?: Record<string, string>
+}
 
 export type SubClient = ((...args: any[]) => Promise<any>) & Client
 
@@ -106,3 +111,12 @@ export type ClientApi<ServerApi extends {}> = {
             ? never
             : () => Promise<ServerApi[KeyType]>
 }
+
+export type Metadata = Record<string, string>
+export type MsgRequestObj = {
+  msgId: MsgId
+  method: NonEmptyArray<Prop>
+  args: Args
+  metadata?: Metadata
+}
+export type Result = Promise<any> | Readable

--- a/lib/validate-message.js
+++ b/lib/validate-message.js
@@ -126,3 +126,27 @@ export function validateResponseMsg(msg) {
     throw new AggregateError(errors, 'Invalid response message')
   }
 }
+
+/**
+ * @param {unknown} metadata
+ * @returns {asserts metadata is import('./types.js').Metadata}
+ */
+export function validateMetadata(metadata) {
+  if (typeof metadata !== 'object' || metadata === null) {
+    throw new TypeError(
+      `Invalid metadata of type ${typeof metadata} (was expecting an object).`,
+    )
+  }
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof key !== 'string') {
+      throw new TypeError(
+        `Invalid metadata key of type ${typeof key} (was expecting a string).`,
+      )
+    }
+    if (typeof value !== 'string') {
+      throw new TypeError(
+        `Invalid metadata value of type ${typeof value} (was expecting a string).`,
+      )
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "ensure-error": "^4.0.0",
         "eventemitter3": "^5.0.1",
         "is-stream": "^4.0.1",
+        "p-defer": "^4.0.1",
         "p-timeout": "^6.1.4",
         "readable-stream": "^4.7.0",
         "serialize-error": "^12.0.0"
@@ -2707,6 +2708,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ensure-error": "^4.0.0",
     "eventemitter3": "^5.0.1",
     "is-stream": "^4.0.1",
+    "p-defer": "^4.0.1",
     "p-timeout": "^6.1.4",
     "readable-stream": "^4.7.0",
     "serialize-error": "^12.0.0"


### PR DESCRIPTION
A request hook allows modifying the request on either the server or client, and adding metadata on the client and reading on the server. The hook can also await the response. This is useful for adding tracing, e.g. Sentry distributed tracing, in an application.