### PR TITLE
chore!: Publishing fixes

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,29 +1,29 @@
 import { EventEmitter } from 'eventemitter3'
-import { ExhaustivenessError, invariant } from './utils.js'
+import { ExhaustivenessError, invariant } from './lib/utils.js'
 import { deserializeError } from 'serialize-error'
 import promiseTimeout from 'p-timeout'
 
-import { isMessagePortLike } from './is-message-port-like.js'
-import { msgType } from './constants.js'
-import { stringify, parse } from './prop-array-utils.js'
-import { validateResponseMsg } from './validate-message.js'
+import { isMessagePortLike } from './lib/is-message-port-like.js'
+import { msgType } from './lib/constants.js'
+import { stringify, parse } from './lib/prop-array-utils.js'
+import { validateResponseMsg } from './lib/validate-message.js'
 import nullLogger from 'abstract-logging'
 import pDefer from 'p-defer'
 
-/** @import {MessageContainer, MsgRequestObj} from './types.js' */
-/** @typedef {import('./types.js').MsgRequest} MsgRequest */
-/** @typedef {import('./types.js').MsgResponse} MsgResponse */
-/** @typedef {import('./types.js').MsgOn} MsgOn */
-/** @typedef {import('./types.js').MsgOff} MsgOff */
-/** @typedef {import('./types.js').MsgEmit} MsgEmit */
-/** @typedef {import('./types.js').Message} Message */
-/** @typedef {import('./types.js').Client} Client */
-/** @typedef {import('./types.js').SubClient} SubClient */
+/** @import {MessageContainer, MsgRequestObj} from './lib/types.js' */
+/** @typedef {import('./lib/types.js').MsgRequest} MsgRequest */
+/** @typedef {import('./lib/types.js').MsgResponse} MsgResponse */
+/** @typedef {import('./lib/types.js').MsgOn} MsgOn */
+/** @typedef {import('./lib/types.js').MsgOff} MsgOff */
+/** @typedef {import('./lib/types.js').MsgEmit} MsgEmit */
+/** @typedef {import('./lib/types.js').Message} Message */
+/** @typedef {import('./lib/types.js').Client} Client */
+/** @typedef {import('./lib/types.js').SubClient} SubClient */
 /**
  * @template {{}} ApiType
- * @typedef {import('./types.js').ClientApi<ApiType>} ClientApi
+ * @typedef {import('./lib/types.js').ClientApi<ApiType>} ClientApi
  */
-/** @typedef {import('./types.js').MessagePortLike} MessagePortLike */
+/** @typedef {import('./lib/types.js').MessagePortLike} MessagePortLike */
 /** @typedef {import('worker_threads').MessagePort} MessagePortNode */
 
 const emitterSubscribeMethods = [
@@ -363,7 +363,7 @@ function concatStreamedResponse(streamedResponse) {
 
 /**
  * @param {string[]} arr
- * @returns {arr is import('./types.js').NonEmptyArray<string>}
+ * @returns {arr is import('./lib/types.js').NonEmptyArray<string>}
  */
 function isNonEmptyStringArray(arr) {
   return arr.length > 0

--- a/index.js
+++ b/index.js
@@ -3,5 +3,5 @@
  * @typedef {import('./lib/types.js').ClientApi<ApiType>} ClientApi
  */
 
-export { createClient } from './lib/client.js'
-export { createServer } from './lib/server.js'
+export { createClient } from './client.js'
+export { createServer } from './server.js'

--- a/package.json
+++ b/package.json
@@ -3,21 +3,20 @@
   "version": "2.0.0",
   "description": "Call methods on an object over RPC",
   "type": "module",
+  "main": "index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js",
       "default": "./index.js"
     },
-    "./client": {
-      "types": "./dist/lib/client.d.ts",
-      "import": "./lib/client.js",
-      "default": "./lib/client.js"
+    "./client.js": {
+      "types": "./dist/client.d.ts",
+      "default": "./client.js"
     },
-    "./server": {
-      "types": "./dist/lib/server.d.ts",
-      "import": "./lib/server.js",
-      "default": "./lib/server.js"
+    "./server.js": {
+      "types": "./dist/server.d.ts",
+      "default": "./server.js"
     }
   },
   "scripts": {
@@ -63,6 +62,8 @@
   "files": [
     "CHANGELOG.md",
     "index.js",
+    "client.js",
+    "server.js",
     "lib/",
     "dist/",
     "examples/"

--- a/server.js
+++ b/server.js
@@ -1,24 +1,24 @@
-import { ExhaustivenessError, invariant } from './utils.js'
+import { ExhaustivenessError, invariant } from './lib/utils.js'
 import { serializeError } from 'serialize-error'
 import nullLogger from 'abstract-logging'
 import { isDuplexStream, isReadableStream } from 'is-stream'
-import { msgType } from './constants.js'
-import { validateMetadata, validateRequestMsg } from './validate-message.js'
-import { parse, stringify } from './prop-array-utils.js'
-import { MessageStream } from './message-stream.js'
-import { isMessagePortLike } from './is-message-port-like.js'
+import { msgType } from './lib/constants.js'
+import { validateMetadata, validateRequestMsg } from './lib/validate-message.js'
+import { parse, stringify } from './lib/prop-array-utils.js'
+import { MessageStream } from './lib/message-stream.js'
+import { isMessagePortLike } from './lib/is-message-port-like.js'
 import { EventEmitter } from 'events'
 import ensureError from 'ensure-error'
 
-/** @import {MsgRequestObj, Result, Metadata, MsgId} from './types.js'*/
-/** @typedef {import('./types.js').MsgRequest} MsgRequest */
-/** @typedef {import('./types.js').MsgResponse} MsgResponse */
-/** @typedef {import('./types.js').MsgOn} MsgOn */
-/** @typedef {import('./types.js').MsgOff} MsgOff */
-/** @typedef {import('./types.js').MsgEmit} MsgEmit */
-/** @typedef {import('./types.js').Message} Message */
-/** @typedef {import('./types.js').NonEmptyArray<string>} NonEmptyStringArray */
-/** @typedef {import('./types.js').MessagePortLike} MessagePortLike */
+/** @import {MsgRequestObj, Result, Metadata, MsgId} from './lib/types.js'*/
+/** @typedef {import('./lib/types.js').MsgRequest} MsgRequest */
+/** @typedef {import('./lib/types.js').MsgResponse} MsgResponse */
+/** @typedef {import('./lib/types.js').MsgOn} MsgOn */
+/** @typedef {import('./lib/types.js').MsgOff} MsgOff */
+/** @typedef {import('./lib/types.js').MsgEmit} MsgEmit */
+/** @typedef {import('./lib/types.js').Message} Message */
+/** @typedef {import('./lib/types.js').NonEmptyArray<string>} NonEmptyStringArray */
+/** @typedef {import('./lib/types.js').MessagePortLike} MessagePortLike */
 /** @typedef {import('worker_threads').MessagePort} MessagePortNode */
 
 /**

--- a/tsconfig.publish.json
+++ b/tsconfig.publish.json
@@ -7,5 +7,5 @@
     "noEmitOnError": true,
     "outDir": "dist"
   },
-  "include": ["lib/**/*", "index.js"]
+  "include": ["lib/**/*", "index.js", "types/**/*"]
 }


### PR DESCRIPTION
This is a breaking change, because it renames the named exports. I don't think anybody is using v2, which was just released, but I don't think it's an issue to go straight to v3.

- Jest seemed to be having issues with resolving the package.json `"exports"` field. I've added a `"main"` field in `package.json` which will work as a fallback for bundlers that don't support `"exports"`
- By naming client and server exports `./client.js` and `./server.js`, and moving the files to root, bundlers that do not support `"exports"` will still work.
- Some type definitions were missing from the published package.


