### PR TITLE
fix: Trying to access a symbol prop should return undefined

### DIFF
--- a/client.js
+++ b/client.js
@@ -240,7 +240,7 @@ export function createClient(
         //   return () => '[rpcProxyClient]'
         // }
         if (typeof prop !== 'string') {
-          throw new Error(`ReferenceError: ${String(prop)} is not defined`)
+          return undefined
         } else if (prop === 'then') {
           return null
         } else if (prop in EventEmitter.prototype) {

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -591,6 +591,17 @@ function runTests(setup) {
     t.end()
   })
 
+  test('Accessing a symbol property returns undefined', (t) => {
+    const { client } = setup(myApi)
+    t.equal(
+      // @ts-expect-error
+      client[Symbol('test')],
+      undefined,
+      'Symbol property returns undefined',
+    )
+    t.end()
+  })
+
   test('console.log on client does not throw', (t) => {
     const { client } = setup(myApi)
     // This was throwing without a trap for util.inspect.custom


### PR DESCRIPTION
Accessing a symbol prop (e.g. `myApi[Symbol.iterator]`) was throwing an error. This is not the behaviour of a regular JS object, which returns `undefined` for non-existent props. This was causing errors when trying to inspect elements with the react native debugger, which does funny things inspecting props (it tries to read the  `prop[Symbol.iterator]` which was throwing when inspecting the api prop).