### PR TITLE
feat: improved logging & simpler Logger type

### DIFF
--- a/client.js
+++ b/client.js
@@ -28,6 +28,13 @@ import { isMessageEvent } from './lib/is-message-event.js'
 /** @typedef {import('./lib/types.js').MessagePortLike} MessagePortLike */
 /** @typedef {import('./lib/types.js').MessageEvent} MessageEvent */
 /** @typedef {(request: Omit<MsgRequestObj, 'metadata'>, next: (request: MsgRequestObj) => Promise<any>) => void} OnRequestHook */
+/** @typedef {import('./lib/types.js').Logger} Logger */
+/**
+ * @typedef {object} ClientOptions
+ * @property {number} [timeout=5000] Optionally set timeout (default 5000)
+ * @property {false | Logger} [logger = false] options.logger Set to `false` to disable logging, or pass a logger (e.g. a pino instance or the global `console`) to enable it
+ * @property {OnRequestHook} [onRequestHook] Optional hook to observe and modify a request and its metadata, and to await the response.
+ */
 
 const emitterSubscribeMethods = [
   'addListener',
@@ -46,10 +53,7 @@ const closeProp = Symbol('close')
  * listens to replies from the server via `receiver`.
  *
  * @param {MessagePortLike} channel MessagePort-like object that must implement an `.addEventListener('message', (event: MessageEvent<any>) => {})` event handler and a `.postMessage()` method.
- * @param {object} [options] Options object
- * @param {number} [options.timeout=5000] Optionally set timeout (default 5000)
- * @param {false | Omit<import('pino').BaseLogger, 'level' | 'silent'>} [options.logger = false] options.logger Set to `false` to disable logging, or pass a pino logger instance to enable logging
- * @param {OnRequestHook} [options.onRequestHook] Optional hook to observe and modify a request and its metadata, and to await the response.
+ * @param {ClientOptions} [options] Options object
  * @returns {ClientApi<ApiType>}
  */
 export function createClient(
@@ -70,6 +74,7 @@ export function createClient(
   let closed = false
 
   channel.addEventListener('message', handleMessageEvent)
+  log.info({ timeout }, 'RPC client created')
 
   /** @param {MsgRequest | MsgOn | MsgOff | MessageContainer} msg */
   function send(msg) {
@@ -212,6 +217,7 @@ export function createClient(
     channel.removeEventListener('message', handleMessageEvent)
     // Reject every in-flight RPC so callers don't have to wait for the
     // per-call timeout to fire when the channel is torn down.
+    const pendingCount = pending.size
     for (const [, [, reject]] of pending) {
       reject(new ChannelClosedError())
     }
@@ -220,6 +226,7 @@ export function createClient(
     // TODO: Should we do this? Or leave it to the user? It's considered "bad
     // practice" to do this
     emitter.removeAllListeners()
+    log.info({ pendingCount }, 'RPC client closed')
   }
 
   const subClientCache = new Map()

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@
 /** @typedef {import('./lib/types.js').MessageEvent} MessageEvent */
 /** @typedef {import('./client.js').OnRequestHook} ClientOnRequestHook */
 /** @typedef {import('./server.js').OnRequestHook} ServerOnRequestHook */
+/** @typedef {import('./lib/types.js').Logger} Logger */
+/** @typedef {import('./client.js').ClientOptions} ClientOptions */
+/** @typedef {import('./server.js').ServerOptions} ServerOptions */
 
 export { createClient } from './client.js'
 export { createServer } from './server.js'

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -131,6 +131,21 @@ export type ClientApi<ServerApi extends {}> = {
             : () => Promise<ServerApi[KeyType]>
 }
 
+type LogFn = (...args: any[]) => void
+
+/**
+ * The subset of a logger interface that RPC Reflector uses. Matches a pino
+ * logger and the global `console` (no `fatal`), so either can be passed as
+ * `options.logger`.
+ */
+export interface Logger {
+  trace: LogFn
+  debug: LogFn
+  info: LogFn
+  warn: LogFn
+  error: LogFn
+}
+
 export type Metadata = Record<string, string>
 export type MsgRequestObj = {
   msgId: MsgId

--- a/server.js
+++ b/server.js
@@ -22,6 +22,12 @@ import { isMessageEvent } from './lib/is-message-event.js'
 /** @typedef {import('./lib/types.js').MessagePortLike} MessagePortLike */
 /** @typedef {import('./lib/types.js').MessageEvent} MessageEvent */
 /** @typedef {(request: MsgRequestObj, next: (request: Omit<MsgRequestObj, 'metadata'>) => Result) => void} OnRequestHook */
+/** @typedef {import('./lib/types.js').Logger} Logger */
+/**
+ * @typedef {object} ServerOptions
+ * @property {false | Logger} [logger = false] options.logger Set to `false` to disable logging, or pass a logger (e.g. a pino instance or the global `console`) to enable it
+ * @property {OnRequestHook} [onRequestHook] Optional hook to observe and modify a request and its metadata, and to await the response.
+ */
 
 /**
  * @public
@@ -33,9 +39,7 @@ import { isMessageEvent } from './lib/is-message-event.js'
  * or a ReadableStream. Your transport stream must be able to encode/decode any
  * values that your handler returns
  * @param {MessagePortLike} messagePort A MessagePort-like object that must implement an `.addEventListener('message', (event: MessageEvent) => void)` event handler and a `.postMessage()` method.
- * @param {object} [options] Options object
- * @param {false | Omit<import('pino').BaseLogger, 'level' | 'silent'>} [options.logger = false] options.logger Set to `false` to disable logging, or pass a pino logger instance to enable logging
- * @param {OnRequestHook} [options.onRequestHook] Optional hook to observe and modify a request and its metadata, and to await the response.
+ * @param {ServerOptions} [options] Options object
  * @returns {{ close: () => void }} An object with a single method `close()` that will stop the server listening to and sending any more messages
  */
 export function createServer(
@@ -54,6 +58,7 @@ export function createServer(
   let subscriptions = new Map()
 
   messagePort.addEventListener('message', handleMessageEvent)
+  log.info('RPC server created')
 
   /** @param {MsgResponse | MsgEmit} msg */
   function send(msg) {
@@ -226,6 +231,7 @@ export function createServer(
     }
     subscriptions.set(encodedEventName, listener)
     emitter.on(eventName, listener)
+    log.debug({ eventName, propArray }, 'Subscribed to handler event')
   }
 
   /** @param {MsgOff} msg */
@@ -249,11 +255,13 @@ export function createServer(
     const listener = subscriptions.get(encodedEventName)
     listener && emitter.removeListener(eventName, listener)
     subscriptions.delete(encodedEventName)
+    log.debug({ eventName, propArray }, 'Unsubscribed from handler event')
   }
 
   return {
     close: () => {
       messagePort.removeEventListener('message', handleMessageEvent)
+      const subscriptionCount = subscriptions.size
       for (const [encodedEventName, listener] of subscriptions.entries()) {
         const [propArray, eventName] = parse(encodedEventName)
         try {
@@ -264,6 +272,7 @@ export function createServer(
         }
       }
       subscriptions = new Map()
+      log.info({ subscriptionCount }, 'RPC server closed')
     },
   }
 }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1,10 +1,9 @@
 import test from 'tape'
-import nullLogger from 'abstract-logging'
 
 import { createClient } from '../index.js'
 import { msgType } from '../lib/constants.js'
 import invalidMessages from './fixtures/invalid-messages.js'
-import { MessagePortLike } from './helpers.js'
+import { MessagePortLike, createTestLogger } from './helpers.js'
 
 test('Client can call methods', (t) => {
   t.plan(1)
@@ -108,10 +107,7 @@ test('Ignores invalid messages', (t) => {
 test('Ignores a message that is not a MessageEvent', (t) => {
   t.plan(1)
   const port = new MessagePortLike(() => {})
-  const logger = {
-    ...nullLogger,
-    msgPrefix: undefined,
-    // @ts-ignore - pino-style warn(obj, msg)
+  const logger = createTestLogger({
     warn(_obj, msg) {
       t.equal(
         msg,
@@ -119,7 +115,7 @@ test('Ignores a message that is not a MessageEvent', (t) => {
         'Warns and ignores the broken message',
       )
     },
-  }
+  })
   createClient(port, { timeout: 200, logger })
   // A correct port delivers `{ data: msg }`; this one emits a shape without
   // `data`, which isn't a MessageEvent and must be ignored.

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -6,13 +6,16 @@ import { EventEmitter as EventEmitter3 } from 'eventemitter3'
 import { readFileSync, createReadStream } from 'fs'
 import { join } from 'path'
 import intoStream from 'into-stream'
-import { MessagePortLikePair, ReadableError } from './helpers.js'
+import {
+  MessagePortLikePair,
+  ReadableError,
+  createTestLogger,
+} from './helpers.js'
 import ensureError from 'ensure-error'
 import { fileURLToPath } from 'url'
 import path from 'path'
 import { pino } from 'pino'
 import { isReadableStream } from 'is-stream'
-import nullLogger from 'abstract-logging'
 import { isErrorWithCode } from 'custom-error-creator'
 
 /** @import {MessagePortLike} from '../index.js' */
@@ -887,23 +890,17 @@ function runTests(setup) {
   test('Error in onRequestHook is ignored', async (t) => {
     const clientHookError = new Error('Test error in client onRequestHook')
     const serverHookError = new Error('Test error in server onRequestHook')
-    const clientLogger = {
-      ...nullLogger,
-      msgPrefix: undefined,
-      // @ts-ignore
+    const clientLogger = createTestLogger({
       error(obj) {
         t.equal(obj.err, clientHookError, 'Client hook error logged')
       },
-    }
+    })
 
-    const serverLogger = {
-      ...nullLogger,
-      msgPrefix: undefined,
-      // @ts-ignore
+    const serverLogger = createTestLogger({
       error(obj) {
         t.equal(obj.err, serverHookError, 'Server hook error logged')
       },
-    }
+    })
 
     const { client } = setup(
       t,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -57,6 +57,24 @@ export class MessagePortLikePair {
   }
 }
 
+/**
+ * A no-op logger satisfying the `Logger` interface, with optional method
+ * overrides for asserting on specific log calls in a test.
+ *
+ * @param {Partial<import('../lib/types.js').Logger>} [overrides]
+ * @returns {import('../lib/types.js').Logger}
+ */
+export function createTestLogger(overrides = {}) {
+  return {
+    trace() {},
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+    ...overrides,
+  }
+}
+
 export class ReadableError extends Readable {
   /** @param {Error} err */
   constructor(err) {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,10 +1,9 @@
 //@ts-nocheck
 import test from 'tape'
-import nullLogger from 'abstract-logging'
 
 import { createServer } from '../index.js'
 import invalidMessages from './fixtures/invalid-messages.js'
-import { MessagePortLike } from './helpers.js'
+import { MessagePortLike, createTestLogger } from './helpers.js'
 
 test('Ignores invalid messages', (t) => {
   t.plan(1)
@@ -41,8 +40,7 @@ test('Ignores invalid messages', (t) => {
 test('Ignores a message that is not a MessageEvent', (t) => {
   t.plan(1)
   const port = new MessagePortLike(() => {})
-  const logger = {
-    ...nullLogger,
+  const logger = createTestLogger({
     warn(_obj, msg) {
       t.equal(
         msg,
@@ -50,7 +48,7 @@ test('Ignores a message that is not a MessageEvent', (t) => {
         'Warns and ignores the broken message',
       )
     },
-  }
+  })
   createServer({}, port, { logger })
   // A correct port delivers `{ data: msg }`; this one emits a shape without
   // `data`, which isn't a MessageEvent and must be ignored.


### PR DESCRIPTION
Replaces the pino BaseLogger option type with a Logger interface (trace/debug/info/warn/error), so any compatible logger — including the global console — can be passed, and pino types no longer leak into the public API.

- Add ClientOptions, ServerOptions and Logger to the public exports
- Add info logging on client/server create and close, and debug logging on event subscribe/unsubscribe (kept off hot paths)
- Share a createTestLogger helper across the test mocks