### PR TITLE
fix: namespace client msgIds to prevent crossed responses

### DIFF
--- a/client.js
+++ b/client.js
@@ -46,6 +46,19 @@ const emitterSubscribeMethods = [
 const emitterUnsubscribeMethods = ['removeListener', 'off']
 const closeProp = Symbol('close')
 
+// Per-call message ids are namespaced into a random band so that the id spaces
+// of two client instances sharing one transport (or one client re-created
+// across a reconnect/reload) don't overlap. A foreign or stale response then
+// carries a msgId outside this instance's band, misses `pending`, and is
+// ignored instead of resolving the wrong call.
+// See https://github.com/digidem/rpc-reflector/issues/46
+//
+// msgId = nonce * COUNTER_RANGE + counter, kept within Number.MAX_SAFE_INTEGER
+// (2**53 - 1) so it survives structured clone / JSON transport exactly: the
+// nonce uses the high 27 bits, the counter the low 26 bits.
+const COUNTER_RANGE = 2 ** 26
+const NONCE_RANGE = 2 ** 27
+
 /**
  * @public
  * @template {{}} ApiType
@@ -65,7 +78,8 @@ export function createClient(
     'Must pass a browser MessagePort, node worker.MessagePort, or MessagePort-like object',
   )
   const log = logger || nullLogger
-  let id = 0
+  const nonceBase = Math.floor(Math.random() * NONCE_RANGE) * COUNTER_RANGE
+  let counter = 0
   /** @type {Map<number, [(value?: any) => void, (reason?: any) => void]>} */
   const pending = new Map() // Messages pending response
   /** @type {Map<number, Array<any>>} */
@@ -316,7 +330,8 @@ export function createClient(
         if (closed) {
           return Promise.reject(new ChannelClosedError())
         }
-        const msgId = id++
+        const msgId = nonceBase + counter
+        counter = (counter + 1) % COUNTER_RANGE
 
         const { resolve, reject, promise } = pDefer()
         pending.set(msgId, [resolve, reject])

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -104,6 +104,70 @@ test('Ignores invalid messages', (t) => {
     )
 })
 
+test('Responses do not cross between clients sharing one transport', (t) => {
+  // Regression for https://github.com/digidem/rpc-reflector/issues/46: two
+  // clients over a single transport used to both number msgIds from 0, so a
+  // late response for one client could resolve the other's pending call.
+  t.plan(3)
+
+  // Each client picks its msgId namespace from Math.random() at creation. Force
+  // two distinct draws so the test is deterministic — a real-world nonce
+  // collision (~1e-8) would be an actual #46 recurrence, not a test artifact.
+  const realRandom = Math.random
+  const nonces = [0.1, 0.6]
+  let draw = 0
+  Math.random = () => nonces[draw++] ?? realRandom()
+  t.teardown(() => {
+    Math.random = realRandom
+  })
+
+  /** @type {import('../lib/types.js').MsgRequest[]} */
+  const requests = []
+  // A single shared port that broadcasts every response to all listeners, as a
+  // real shared MessagePort does. Both clients attach to it.
+  const sharedPort = new MessagePortLike((msg) => requests.push(msg))
+
+  const clientA = createClient(/** @type {any} */ (sharedPort), {
+    timeout: 200,
+  })
+  const clientB = createClient(/** @type {any} */ (sharedPort), {
+    timeout: 200,
+  })
+
+  const callA = /** @type {any} */ (clientA).deviceId()
+  const callB = /** @type {any} */ (clientB).createProject()
+
+  const [reqA, reqB] = requests
+  t.notEqual(reqA[1], reqB[1], 'The two clients use distinct msgIds')
+
+  // Deliver responses in crossed order: clientA's response carries clientB's
+  // value first. Each is broadcast to both clients; only the matching msgId
+  // resolves.
+  sharedPort.dispatchEvent(
+    /** @type {any} */ ({
+      type: 'message',
+      data: [msgType.RESPONSE, reqA[1], null, 'deviceId-value'],
+    }),
+  )
+  sharedPort.dispatchEvent(
+    /** @type {any} */ ({
+      type: 'message',
+      data: [msgType.RESPONSE, reqB[1], null, 'project-value'],
+    }),
+  )
+
+  callA.then(
+    /** @param {any} value */ (value) =>
+      t.equal(value, 'deviceId-value', 'clientA resolves with its own value'),
+    t.fail,
+  )
+  callB.then(
+    /** @param {any} value */ (value) =>
+      t.equal(value, 'project-value', 'clientB resolves with its own value'),
+    t.fail,
+  )
+})
+
 test('Ignores a message that is not a MessageEvent', (t) => {
   t.plan(1)
   const port = new MessagePortLike(() => {})


### PR DESCRIPTION
## Problem

`createClient` numbered request ids from a per-instance counter starting at `0` and matched responses by that bare `msgId`. When two clients share one transport — or one client is re-created while a request is still in flight over a persistent transport — their id spaces overlap (both start at `0`), so a response intended for one client can resolve a *different* client's pending entry, producing a crossed response.

This was hit in `@comapeo/core-react-native`, where a bundling bug loaded two client instances over one native socket; a late `deviceId()` (msgId 0) response resolved another client's `createProject()` (also msgId 0). The same shape can occur with a single client across a reconnect/reload.

Fixes #46.

## Fix

Each client instance picks a random nonce at creation and namespaces its msgIds into a disjoint numeric band:

```js
const nonceBase = Math.floor(Math.random() * 2 ** 27) * 2 ** 26
const msgId = nonceBase + counter   // counter wraps at 2**26
```

`msgId` stays a plain integer ≤ `Number.MAX_SAFE_INTEGER` (exactly: the high 27 bits hold the nonce, the low 26 the counter), so it survives structured clone / JSON transport unchanged and still passes the `typeof msgId === 'number'` validators. A foreign or stale response carries an id outside this instance's band, misses `pending`, and hits the existing `Received unknown message ID (ignored)` path instead of resolving the wrong call.

This keeps the wire format intact — the server echoes `msgId` verbatim, so old↔new clients/servers interoperate in both directions. No breaking change.

## Trade-offs

The fix is probabilistic: two clients on one transport collide on a nonce with probability ~7.5e-9 (2 clients) up to ~3.7e-3 (1000 clients); ~50% only at ~13,600 clients. A collision merely degrades to the prior behaviour for that pair rather than introducing anything worse. The per-instance counter wraps every 2²⁶ (~67M) calls, which only matters if a 67M-old call is still pending — impossible in practice since `pending` clears on response or timeout.

## Tests

Added a regression test with two clients over a shared broadcast transport, delivering responses in crossed order and asserting each resolves with its own value. `Math.random` is stubbed in that test to force distinct nonces so it's deterministic. Full suite and `tsc` pass.